### PR TITLE
Include autoloader using PATH_ROOT

### DIFF
--- a/environment.php
+++ b/environment.php
@@ -63,6 +63,6 @@ if (function_exists('mb_internal_encoding')) {
 }
 
 // Include the core autoloader.
-if (!include_once __DIR__.'/vendor/autoload.php') {
-    die("Could not find the autoloader. Did you forget to run 'composer install' in '".__DIR__."' ?\n");
+if (!include_once PATH_ROOT.'/vendor/autoload.php') {
+    die("Could not find the autoloader. Did you forget to run 'composer install' in '".PATH_ROOT."' ?\n");
 }


### PR DESCRIPTION
Use `PATH_ROOT` instead of `__DIR__` to include the composer autoloader.